### PR TITLE
Removed Warnings 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS ?= -Werror -Wall
+CFLAGS ?= -Wall -Wextra
 
 libs = msg.c
 objs = $(libs:.c=.o)

--- a/ct/ct.c
+++ b/ct/ct.c
@@ -156,7 +156,7 @@ report(T t[])
 
 
 int
-main(int argc, char *argv[])
+main(void)
 {
     run(ctmain);
     return report(ctmain);

--- a/ct/gen
+++ b/ct/gen
@@ -17,6 +17,7 @@ tests() {
 
 gen() {
     printf '#include "internal.h"\n'
+    printf '#include <stdlib.h>\n'
     printf '\n'
 
     for t in "$@"
@@ -26,9 +27,9 @@ gen() {
 
     printf 'T ctmain[] = {\n'
     for t in "$@"
-    do printf '    {%s, "%s"},\n' $t $t
+    do printf '    {%s, "%s", -1, -1},\n' $t $t
     done
-    printf '    {},\n'
+    printf '    {NULL, NULL, -1, -1},\n'
     printf '};\n'
 }
 


### PR DESCRIPTION
Hi kr,

We have been using your ct test framework for our Unix Systems Programming class all semester, and for our final project we have decided to create a few additions to the framework.

In total, we are making 3 changes to ct. Hopefully you find these additions useful and would like to incorporate them into your current project. Our goals are:
1. Fix all warnings that result from compiling with -Wall and -Werror.
2. Allow the user to specify functions ctsetup and ctteardown in each cttest file. These functions will run before and after every test in the file.
3. Create a framework for testing over a network. This section would include the majority of our work. The idea would be to allow a user to write a function for each node in their network. All of these functions would be combined into a single test that sets up each node and starts all of the functions. This section would not impact any of the other parts of ct. The network test would simply be transformed into a regular cttest using our code. Then it would run under the same framework as a regular test.

We would like to make sure all of our additions are as useful as possible without adding any unnecessary complications for people running ct. If you have any questions or feedback about these goals, please do not hesitate to send me a message, or shoot me an email at jsmit272@jhu.edu. 

This current pull request accomplishes the first goal. Code has been added to fix the warnings for uninitialized objects in the array and unused parameters in the main function. Neither of these warnings impacted how ct worked, but fixing them helps clean up ct's output, allowing the user to more easily spot any warnings that are coming from their own files.

Once we have completed the other goals, I'll send you two more pull requests, with each of those features added.

Thanks for taking the time to read through this request,
Josh, Carolyn, and Leah
