### PR TITLE
fix `initializer element is not constant` error

### DIFF
--- a/ct/ct.c
+++ b/ct/ct.c
@@ -23,9 +23,9 @@ static int rjobfd = -1, wjobfd = -1;
 static int64 bstart, bdur;
 static int btiming; // bool
 static int64 bbytes;
-static const int64 Second = 1000 * 1000 * 1000;
-static const int64 BenchTime = Second;
-static const int MaxN = 1000 * 1000 * 1000;
+enum { Second = 1000 * 1000 * 1000 };
+enum { BenchTime = Second };
+enum { MaxN = 1000 * 1000 * 1000 };
 
 
 


### PR DESCRIPTION
I faced this error on an (old) 10.6 Mac OS X equipped with GCC 4.2.1 - clang 3.0 does not complain.

It sounds as if only [_literal constants_](http://stackoverflow.com/a/3025106/1688185) can be used (in C) for such assigments. I found this [suggestion](http://stackoverflow.com/a/795189/1688185) to work with `enum`-s instead of macros pretty useful.
