### PR TITLE
Switch from _exit() to exit(), rework fflush().

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,13 +19,17 @@ in the group will be killed after the test finishes. This
 means your test can fork without having to worry about
 cleaning up its descendants.
 - CT participates in GNU make's jobserver protocol. If you
-put a `+` in front of the _ctcheck command (as in the sample
+put a `+` in front of the `_ctcheck` command (as in the sample
 makefile) and run make with its `-jN` flag, for example
 `make -j16 check`, CT will run tests concurrently (and
 hopefully in parallel).
 - A scratch directory can be obtained by calling ctdir()
 inside the test. This directory will be removed by the test
 runner after the test finishes.
+- If you want to perform  *test coverage analysis* using `gcov`
+please be aware that `gcov` is not necessarily multi-process-safe.
+If you get strange coverage data, try `-j1` and avoid forking in
+your test cases.
 
 ## Terminal Output
 

--- a/ct/ct.c
+++ b/ct/ct.c
@@ -76,8 +76,7 @@ ctfail(void)
 void
 ctfailnow(void)
 {
-    fflush(stdout);
-    fflush(stderr);
+    fflush(NULL);
     abort();
 }
 
@@ -194,6 +193,7 @@ start(Test *t)
     if (mkdtemp(t->dir) == NULL) {
 	die(1, errno, "mkdtemp");
     }
+    fflush(NULL);
     t->pid = fork();
     if (t->pid < 0) {
         die(1, errno, "fork");
@@ -213,7 +213,7 @@ start(Test *t)
         if (fail) {
             ctfailnow();
         }
-        _exit(0);
+        exit(0);
     }
     setpgid(t->pid, t->pid);
 }
@@ -304,6 +304,7 @@ runbenchn(Benchmark *b, int n)
     if (mkdtemp(b->dir) == NULL) {
 	die(1, errno, "mkdtemp");
     }
+    fflush(NULL);
     int pid = fork();
     if (pid < 0) {
         die(1, errno, "fork");
@@ -324,7 +325,7 @@ runbenchn(Benchmark *b, int n)
         ctstoptimer();
         write(durfd, &bdur, sizeof bdur);
         write(durfd, &bbytes, sizeof bbytes);
-        _exit(0);
+        exit(0);
     }
     setpgid(pid, pid);
 


### PR DESCRIPTION
CT runs each test case and benchmark in its own process; those processes
end with a call to _exit(). However, gcov writes coverage data in an
atexit() function which doesn't get called from _exit(). So we switch to
exit() to enable test coverage analysis. Since exit() flushes files, we
had to rework our fflush() strategy as well.