### PR TITLE
ct/gen: fix zero struct to satisfy old version of clang with -Wextra enabled

### DIFF
--- a/ct/gen
+++ b/ct/gen
@@ -35,12 +35,12 @@ printf 'Test ctmaintest[] = {\n'
 for t in $ts
 do printf '    {%s, "%s", 0, 0, 0, TmpDirPat},\n' $t $t
 done
-printf '    {0},\n'
+printf '    {.f = 0},\n'
 printf '};\n'
 
 printf 'Benchmark ctmainbench[] = {\n'
 for b in $bs
 do printf '    {%s, "%s", 0, 0, 0, TmpDirPat},\n' $b $b
 done
-printf '    {0},\n'
+printf '    {.f = 0},\n'
 printf '};\n'


### PR DESCRIPTION
This change is to make some old compilers accept this initializer.
See https://github.com/beanstalkd/beanstalkd/issues/443